### PR TITLE
Switching to logger level trace when dev fig is not used.

### DIFF
--- a/fig-core/src/main/java/twigkit/fig/loader/MergedPropertiesLoader.java
+++ b/fig-core/src/main/java/twigkit/fig/loader/MergedPropertiesLoader.java
@@ -49,10 +49,10 @@ public class MergedPropertiesLoader implements Loader {
                 // Merge the secondary fig into the primary fig.
                 FigUtils.mergeFig(primaryFig, secondaryFig);
             } else {
-                logger.warn("No configs found at: {}. Using primary fig.", pathToSecondaryFig);
+                logger.trace("No configs found at: {}. Using primary fig.", pathToSecondaryFig);
             }
         } else {
-            logger.warn("Fig folder not found: {}. Using primary fig.", pathToSecondaryFig);
+            logger.trace("Fig folder not found: {}. Using primary fig.", pathToSecondaryFig);
         }
     }
 


### PR DESCRIPTION
Resolves #4 : visual inspection with twigkit-gsa application startup that logging level is being respected @bjarkih 
