### PR TITLE
Adding case for handling empty config paths

### DIFF
--- a/fig-core/src/main/java/twigkit/fig/loader/MergedPropertiesLoader.java
+++ b/fig-core/src/main/java/twigkit/fig/loader/MergedPropertiesLoader.java
@@ -36,25 +36,35 @@ public class MergedPropertiesLoader implements Loader {
      * @param fig The primary {@link Fig}
      */
     public void load(Fig fig) {
-        if (pathToPrimaryFig != null) {
+        if (pathToPrimaryFig != null && !pathToPrimaryFig.isEmpty()) {
             new PropertiesLoader(pathToPrimaryFig).load(fig);
+            logger.trace("Primary fig loaded.");
 
-            if (pathToSecondaryFig != null) {
+            if (pathToSecondaryFig != null && !pathToSecondaryFig.isEmpty()) {
                 File secondaryFigRootFolder = FileUtils.getResourceAsFile(pathToSecondaryFig);
 
                 if (secondaryFigRootFolder != null && secondaryFigRootFolder.exists()) {
                     Fig secondaryFig = Fig.getInstance(new PropertiesLoader(pathToSecondaryFig));
                     secondaryFig.reload(); // ensure the secondary fig is up-to-date
+                    logger.trace("Secondary fig loaded.");
+
                     FigUtils.merge(fig, secondaryFig);
+                    logger.trace("Secondary fig merged with primary fig.");
                 } else {
-                    logger.trace("Secondary fig {} not found. Falling back to primary.", pathToSecondaryFig);
+                    logger.debug("Path to secondary fig: \"{}\" is invalid. Falling back to primary.", pathToSecondaryFig);
                 }
             } else {
-                logger.trace("Secondary fig {} not found. Falling back to primary.", pathToSecondaryFig);
+                logger.debug("Path to secondary fig: \"{}\" is invalid. Falling back to primary.", pathToSecondaryFig);
             }
         } else {
-            logger.trace("Primary fig {} not found. Falling back to secondary", pathToPrimaryFig);
-            new PropertiesLoader(pathToSecondaryFig).load(fig);
+            logger.debug("Path to primary fig: \"{}\" is invalid. Attempting to load secondary...", pathToPrimaryFig);
+
+            if (pathToSecondaryFig != null && !pathToSecondaryFig.isEmpty()) {
+                new PropertiesLoader(pathToSecondaryFig).load(fig);
+                logger.trace("Secondary fig loaded");
+            } else {
+                logger.error("Both the path to the primary fig: \"{}\" and the path to the secondary fig: \"{}\" are invalid. Unable to load configurations.", pathToPrimaryFig, pathToSecondaryFig);
+            }
         }
     }
 

--- a/fig-core/src/test/java/twigkit.fig/loader/MergedPropertiesLoaderTest.java
+++ b/fig-core/src/test/java/twigkit.fig/loader/MergedPropertiesLoaderTest.java
@@ -135,4 +135,29 @@ public class MergedPropertiesLoaderTest {
         new ConfigTreeWriter(fig.get("companies"));
         new ConfigTreeWriter(fig.get("people"));
     }
+
+    @Test
+    public void testFallbackFigIsReturnedWhenTheOtherIsEmpty() {
+        Fig fig1 = Fig.getInstance(new PropertiesLoader("confs"));
+        Fig fig2 = Fig.getInstance(new MergedPropertiesLoader("confs", ""));
+
+        Iterator iterator = fig1.configs().iterator();
+        for (Config config2 : fig2.configs()) {
+            assertEquals(iterator.next(), config2);
+        }
+
+        fig1 = Fig.getInstance(new PropertiesLoader("confs"));
+        fig2 = Fig.getInstance(new MergedPropertiesLoader("", "confs"));
+
+        iterator = fig1.configs().iterator();
+        for (Config config2 : fig2.configs()) {
+            assertEquals(iterator.next(), config2);
+        }
+    }
+
+    @Test
+    public void testFigIsEmptyWhenBothPrimaryAndSecondaryFigPathsAreEmpty() {
+        Fig fig = Fig.getInstance(new MergedPropertiesLoader("", ""));
+        assertEquals(fig.configs().size(), 0);
+    }
 }


### PR DESCRIPTION
Resolves #15 If the path to a fig is empty the other is treated as a fallback, if that fig has a valid path. If both fig paths are empty then no configs are loaded and an error is reported in the log. 
