### PR TITLE
Trimming string only if it is not empty

### DIFF
--- a/fig-core/src/main/java/twigkit/fig/Value.java
+++ b/fig-core/src/main/java/twigkit/fig/Value.java
@@ -81,7 +81,11 @@ public class Value<T> implements Serializable {
      */
     public String as_string() {
         if (value != null) {
-            return value.toString().trim();
+            if (!value.toString().trim().isEmpty()) {
+                return value.toString().trim();
+            } else {
+                return value.toString();
+            }
         }
         return "";
     }


### PR DESCRIPTION
Resolves #26 

This change ensure only non-empty strings are trimmed. With the previous implementation, the spacing on LP was broken as a space was assigned to one of the parameters in a processor configuration